### PR TITLE
Update ImageSharp version to fix CVE-2024-41131

### DIFF
--- a/src/ManiaMap/ManiaMap.csproj
+++ b/src/ManiaMap/ManiaMap.csproj
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/mpewsey/ManiaMap</RepositoryUrl>
     <PackageTags>procedural-generation;roguelike;metroidvania;videogames</PackageTags>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-	<VersionPrefix>2.5.0</VersionPrefix>
+	<VersionPrefix>2.5.1</VersionPrefix>
 	<Configurations>Debug;Release;Unity</Configurations>
 	<PackageProjectUrl>https://mpewsey.github.io/ManiaMap/</PackageProjectUrl>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -69,7 +69,7 @@
 
   <ItemGroup>
     <PackageReference Include="MPewsey.Common" Version="0.0.13" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
These changes update the ImageSharp version to resolve https://nvd.nist.gov/vuln/detail/CVE-2024-41131