### PR TITLE
Update ImageSharp version to resolve CVE-2025-27598

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}

--- a/src/ManiaMap/ManiaMap.csproj
+++ b/src/ManiaMap/ManiaMap.csproj
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/mpewsey/ManiaMap</RepositoryUrl>
     <PackageTags>procedural-generation;roguelike;metroidvania;videogames</PackageTags>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-	<VersionPrefix>2.5.1</VersionPrefix>
+	<VersionPrefix>2.5.2</VersionPrefix>
 	<Configurations>Debug;Release;Unity</Configurations>
 	<PackageProjectUrl>https://mpewsey.github.io/ManiaMap/</PackageProjectUrl>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/ManiaMap/ManiaMap.csproj
+++ b/src/ManiaMap/ManiaMap.csproj
@@ -69,7 +69,7 @@
 
   <ItemGroup>
     <PackageReference Include="MPewsey.Common" Version="0.0.13" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates ImageSharp version to resolve CVE-2025-27598.